### PR TITLE
Reset colour scheme on the website

### DIFF
--- a/misc/custom.scss
+++ b/misc/custom.scss
@@ -9,9 +9,9 @@ $primary: #1D1D1D;
 $secondary: #A05A1B;
 $secondary-hover: lighten($secondary, 10%);
 
-$media-color-one: #934710;
-$media-color-two: #01828E;
-$media-color-three: #B3466E;
+$media-color-one: #B3466E;
+$media-color-two: #934710;
+$media-color-three: #01828E;
 $media-color-four: #49759A;
 $media-color-five: #00838f;
 


### PR DESCRIPTION
Isomer found a bug on the website and attempted fixed it. The results of fixing the bug had cause our colour scheme to flip. This pull is to reset back to the original colour scheme.