### PR TITLE
New blog post; re-upload FP2021

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,9 +19,9 @@ sections:
         - title: Who Are the Lost Generation of COVID-19?
           description: CSF Blog Post
           url: https://pmo-csf.medium.com/who-are-the-lost-generation-of-covid-19-5ea57e5e19ae
-        - title: "Time Banks: Rethinking Value, Labour, and Community"
+        - title: A World Reaching Inflection Point
           description: CSF Blog Post
-          url: https://pmo-csf.medium.com/time-banks-rethinking-value-labour-and-community-c406ef24a68a
+          url: https://pmo-csf.medium.com/a-world-reaching-inflection-point-9afdec2d1e00
   - resources:
       title: Latest News
       subtitle: Media Centre

--- a/media-centre/publications/_posts/2021-12-23-post-foresight.md
+++ b/media-centre/publications/_posts/2021-12-23-post-foresight.md
@@ -3,17 +3,14 @@ layout: post
 title: Foresight
 date: 2021-12-23T00:00:00.000Z
 permalink: /media-centre/publications/Foresight-Series
-
 ---
-
-
 #### **Foresight (Series)**
 
 _Foresight_ is the Centre for Strategic Futures' biennial publication covering research into international megatrends and emerging issues. It focuses on the _future_ of these developments -- how these trends and issues may develop, and their implications. It also contains CSF’s reflections and experiences in foresight methods and major highlights from our work.
 
-[Foresight 2021 (8MB)](/files/media-centre/publications/CSF_Foresight_2021.pdf){:target="_blank"}  
+[Foresight 2021 (8MB)](https://go.gov.sg/csfforesight2021){:target="_blank"}  
 [Foresight 2019 (10MB)](/files/media-centre/publications/CSF_Foresight_2019.pdf){:target="_blank"}   
 [Foresight 2017 (15MB)](/files/media-centre/publications/csf-foresight_fa-for-server_interactive-2.pdf){:target="_blank"}      
 [Foresight 2015 (5MB)](/files/media-centre/publications/csf-report-2015.pdf){:target="_blank"}     
 [Foresight 2014 (4MB)](/files/media-centre/publications/csf-report-2014.pdf){:target="_blank"}  
-[Foresight 2012 (5MB)](/files/media-centre/publications/csf-report-2012.pdf){:target="_blank"}  
+[Foresight 2012 (5MB)](/files/media-centre/publications/csf-report-2012.pdf){:target="_blank"}


### PR DESCRIPTION
Changed highlight reel to broadcast new blog post. Replace FP2021 file with the new low-res one. As it's no longer possible to upload files bigger than 5MB, have uploaded it to the go.gov.sg site and linked it from there instead.